### PR TITLE
Add additional tests and methods in ResidentDescriptorBuilder class

### DIFF
--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
@@ -7,7 +7,6 @@ import static seedu.rc4hdb.commons.core.Messages.MESSAGE_RESIDENTS_LISTED_OVERVI
 import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
 import static seedu.rc4hdb.testutil.TypicalResidents.ALICE;
 import static seedu.rc4hdb.testutil.TypicalResidents.AMY;
-import static seedu.rc4hdb.testutil.TypicalResidents.BENSON;
 import static seedu.rc4hdb.testutil.TypicalResidents.DANIEL;
 import static seedu.rc4hdb.testutil.TypicalResidents.ELLE;
 import static seedu.rc4hdb.testutil.TypicalResidents.FIONA;

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
@@ -7,6 +7,8 @@ import static seedu.rc4hdb.commons.core.Messages.MESSAGE_RESIDENTS_LISTED_OVERVI
 import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
 import static seedu.rc4hdb.testutil.TypicalResidents.ALICE;
 import static seedu.rc4hdb.testutil.TypicalResidents.AMY;
+import static seedu.rc4hdb.testutil.TypicalResidents.BENSON;
+import static seedu.rc4hdb.testutil.TypicalResidents.DANIEL;
 import static seedu.rc4hdb.testutil.TypicalResidents.ELLE;
 import static seedu.rc4hdb.testutil.TypicalResidents.FIONA;
 import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
@@ -39,8 +41,8 @@ public class FilterCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withName(ALICE.getName().toString())
-                .withPhone(ALICE.getPhone().toString()).build();
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withName(ALICE.getName())
+                .withPhone(ALICE.getPhone()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 1);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -52,7 +54,7 @@ public class FilterCommandTest {
 
     @Test
     public void execute_nameSpecifiedUnfilteredList_success() {
-        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withName(ALICE.getName().toString()).build();
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withName(ALICE.getName()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 1);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -64,7 +66,7 @@ public class FilterCommandTest {
 
     @Test
     public void execute_phoneSpecifiedUnfilteredList_success() {
-        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withPhone(ALICE.getPhone().toString()).build();
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withPhone(ALICE.getPhone()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 1);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -76,7 +78,7 @@ public class FilterCommandTest {
 
     @Test
     public void execute_emailSpecifiedUnfilteredList_success() {
-        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withEmail(ALICE.getEmail().toString()).build();
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder().withEmail(ALICE.getEmail()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 1);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -90,7 +92,7 @@ public class FilterCommandTest {
     @Test
     public void execute_matricNumberSpecifiedUnfilteredList_success() {
         ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
-                .withMatricNumber(ALICE.getMatricNumber().toString()).build();
+                .withMatricNumber(ALICE.getMatricNumber()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 1);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -103,7 +105,7 @@ public class FilterCommandTest {
     @Test
     public void execute_houseSpecifiedUnfilteredList_success() {
         ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
-                .withHouse(ALICE.getHouse().toString()).build();
+                .withHouse(ALICE.getHouse()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 2);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -116,7 +118,7 @@ public class FilterCommandTest {
     @Test
     public void execute_genderSpecifiedUnfilteredList_success() {
         ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
-                .withGender(ALICE.getGender().toString()).build();
+                .withGender(ALICE.getGender()).build();
         String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 3);
         AttributesMatchKeywordsPredicate predicate =
                 new AttributesMatchKeywordsPredicate(descriptor);
@@ -124,6 +126,19 @@ public class FilterCommandTest {
         expectedModel.updateFilteredResidentList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE, ELLE, FIONA), model.getFilteredResidentList());
+    }
+
+    @Test
+    public void execute_tagsSpecifiedUnfilteredList_success() {
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
+                .withTags(ALICE.getTags()).build();
+        String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 2);
+        AttributesMatchKeywordsPredicate predicate =
+                new AttributesMatchKeywordsPredicate(descriptor);
+        FilterCommand command = new FilterCommand(descriptor);
+        expectedModel.updateFilteredResidentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, DANIEL), model.getFilteredResidentList());
     }
 
 

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
@@ -140,6 +140,19 @@ public class FilterCommandTest {
         assertEquals(Arrays.asList(ALICE, DANIEL), model.getFilteredResidentList());
     }
 
+    @Test
+    public void execute_roomSpecifiedUnfilteredList_success() {
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
+                .withRoom(ALICE.getRoom()).build();
+        String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 1);
+        AttributesMatchKeywordsPredicate predicate =
+                new AttributesMatchKeywordsPredicate(descriptor);
+        FilterCommand command = new FilterCommand(descriptor);
+        expectedModel.updateFilteredResidentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredResidentList());
+    }
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommandTest.java
@@ -7,6 +7,8 @@ import static seedu.rc4hdb.commons.core.Messages.MESSAGE_RESIDENTS_LISTED_OVERVI
 import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
 import static seedu.rc4hdb.testutil.TypicalResidents.ALICE;
 import static seedu.rc4hdb.testutil.TypicalResidents.AMY;
+import static seedu.rc4hdb.testutil.TypicalResidents.ELLE;
+import static seedu.rc4hdb.testutil.TypicalResidents.FIONA;
 import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
 
 import java.util.Arrays;
@@ -84,6 +86,7 @@ public class FilterCommandTest {
         assertEquals(Arrays.asList(ALICE), model.getFilteredResidentList());
     }
 
+
     @Test
     public void execute_matricNumberSpecifiedUnfilteredList_success() {
         ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
@@ -95,6 +98,32 @@ public class FilterCommandTest {
         expectedModel.updateFilteredResidentList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE), model.getFilteredResidentList());
+    }
+
+    @Test
+    public void execute_houseSpecifiedUnfilteredList_success() {
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
+                .withHouse(ALICE.getHouse().toString()).build();
+        String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 2);
+        AttributesMatchKeywordsPredicate predicate =
+                new AttributesMatchKeywordsPredicate(descriptor);
+        FilterCommand command = new FilterCommand(descriptor);
+        expectedModel.updateFilteredResidentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, FIONA), model.getFilteredResidentList());
+    }
+
+    @Test
+    public void execute_genderSpecifiedUnfilteredList_success() {
+        ResidentDescriptor descriptor = new ResidentDescriptorBuilder()
+                .withGender(ALICE.getGender().toString()).build();
+        String expectedMessage = String.format(MESSAGE_RESIDENTS_LISTED_OVERVIEW, 3);
+        AttributesMatchKeywordsPredicate predicate =
+                new AttributesMatchKeywordsPredicate(descriptor);
+        FilterCommand command = new FilterCommand(descriptor);
+        expectedModel.updateFilteredResidentList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, ELLE, FIONA), model.getFilteredResidentList());
     }
 
 

--- a/src/test/java/seedu/rc4hdb/testutil/ResidentDescriptorBuilder.java
+++ b/src/test/java/seedu/rc4hdb/testutil/ResidentDescriptorBuilder.java
@@ -4,8 +4,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Tags;
-
 import seedu.rc4hdb.model.resident.Resident;
 import seedu.rc4hdb.model.resident.ResidentDescriptor;
 import seedu.rc4hdb.model.resident.fields.Email;

--- a/src/test/java/seedu/rc4hdb/testutil/ResidentDescriptorBuilder.java
+++ b/src/test/java/seedu/rc4hdb/testutil/ResidentDescriptorBuilder.java
@@ -4,6 +4,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Tags;
+
 import seedu.rc4hdb.model.resident.Resident;
 import seedu.rc4hdb.model.resident.ResidentDescriptor;
 import seedu.rc4hdb.model.resident.fields.Email;
@@ -54,10 +56,27 @@ public class ResidentDescriptorBuilder {
     }
 
     /**
+     * Convenience method for {@code withName} method.
+     */
+    public ResidentDescriptorBuilder withName(Name name) {
+        descriptor.setName(name);
+        return this;
+    }
+
+
+    /**
      * Sets the {@code Phone} of the {@code ResidentDescriptor} that we are building.
      */
     public ResidentDescriptorBuilder withPhone(String phone) {
         descriptor.setPhone(new Phone(phone));
+        return this;
+    }
+
+    /**
+     * Convenience method for {@code withPhone} method.
+     */
+    public ResidentDescriptorBuilder withPhone(Phone phone) {
+        descriptor.setPhone(phone);
         return this;
     }
 
@@ -70,10 +89,26 @@ public class ResidentDescriptorBuilder {
     }
 
     /**
+     * Convenience method for {@code withEmail} method.
+     */
+    public ResidentDescriptorBuilder withEmail(Email email) {
+        descriptor.setEmail(email);
+        return this;
+    }
+
+    /**
      * Sets the {@code Room} of the {@code ResidentDescriptor} that we are building.
      */
     public ResidentDescriptorBuilder withRoom(String room) {
         descriptor.setRoom(new Room(room));
+        return this;
+    }
+
+    /**
+     * Convenience method for {@code withRoom} method.
+     */
+    public ResidentDescriptorBuilder withRoom(Room room) {
+        descriptor.setRoom(room);
         return this;
     }
 
@@ -86,6 +121,15 @@ public class ResidentDescriptorBuilder {
     }
 
     /**
+     * Convenience method for {@code withGender} method.
+     */
+    public ResidentDescriptorBuilder withGender(Gender gender) {
+        descriptor.setGender(gender);
+        return this;
+    }
+
+
+    /**
      * Sets the {@code House} of the {@code ResidentDescriptor} that we are building.
      */
     public ResidentDescriptorBuilder withHouse(String house) {
@@ -94,10 +138,25 @@ public class ResidentDescriptorBuilder {
     }
 
     /**
+     * Convenience method for {@code withHouse} method.
+     */
+    public ResidentDescriptorBuilder withHouse(House house) {
+        descriptor.setHouse(house);
+        return this;
+    }
+
+    /**
      * Sets the {@code MatricNumber} of the {@code ResidentDescriptor} that we are building.
      */
     public ResidentDescriptorBuilder withMatricNumber(String matricNumber) {
         descriptor.setMatricNumber(new MatricNumber(matricNumber));
+        return this;
+    }
+    /**
+     * Convenience method for {@code withMatricNumber} method.
+     */
+    public ResidentDescriptorBuilder withMatricNumber(MatricNumber matricNumber) {
+        descriptor.setMatricNumber(matricNumber);
         return this;
     }
 
@@ -110,6 +169,15 @@ public class ResidentDescriptorBuilder {
         descriptor.setTags(tagSet);
         return this;
     }
+
+    /**
+     * Convenience method for {@code withTags} method.
+     */
+    public ResidentDescriptorBuilder withTags(Set<Tag> tags) {
+        descriptor.setTags(tags);
+        return this;
+    }
+
 
     public ResidentDescriptor build() {
         return descriptor;


### PR DESCRIPTION
Fixes #89 

Additional tests are used to validate the functionalities of fields in the filter feature that were not isolated and tested. 

The methods added are used to overload current methods in ResidentDescriptorBuilder to make the code cleaner and easier for future use of the class. 