### PR TITLE
Update command class

### DIFF
--- a/src/main/java/seedu/rc4hdb/logic/commands/Command.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/Command.java
@@ -3,6 +3,6 @@ package seedu.rc4hdb.logic.commands;
 /**
  * Represents a command with hidden internal logic and the ability to be executed. Exists for polymorphism purposes.
  */
-public abstract class Command {
+public interface Command {
 
 }

--- a/src/main/java/seedu/rc4hdb/logic/commands/misccommands/ExitCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/misccommands/ExitCommand.java
@@ -5,7 +5,7 @@ import seedu.rc4hdb.logic.commands.CommandResult;
 /**
  * Terminates the program.
  */
-public class ExitCommand extends MiscCommand {
+public class ExitCommand implements MiscCommand {
 
     public static final String COMMAND_WORD = "exit";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/misccommands/HelpCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/misccommands/HelpCommand.java
@@ -5,7 +5,7 @@ import seedu.rc4hdb.logic.commands.CommandResult;
 /**
  * Format full help instructions for every command for display.
  */
-public class HelpCommand extends MiscCommand {
+public class HelpCommand implements MiscCommand {
 
     public static final String COMMAND_WORD = "help";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/misccommands/MiscCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/misccommands/MiscCommand.java
@@ -7,7 +7,7 @@ import seedu.rc4hdb.logic.commands.exceptions.CommandException;
 /**
  * Represents a command that does not directly interact with any components.
  */
-public abstract class MiscCommand extends Command {
+public interface MiscCommand extends Command {
 
     /**
      * Executes the command and returns the result message.
@@ -15,6 +15,6 @@ public abstract class MiscCommand extends Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute() throws CommandException;
+    CommandResult execute() throws CommandException;
 
 }

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/AddCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/AddCommand.java
@@ -18,7 +18,7 @@ import seedu.rc4hdb.model.resident.Resident;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends ModelCommand {
+public class AddCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "add";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ClearCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ClearCommand.java
@@ -9,7 +9,7 @@ import seedu.rc4hdb.model.ResidentBook;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends ModelCommand {
+public class ClearCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Resident book has been cleared!";

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/DeleteCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/DeleteCommand.java
@@ -14,7 +14,7 @@ import seedu.rc4hdb.model.resident.Resident;
 /**
  * Deletes a resident identified using it's displayed index from the resident book.
  */
-public class DeleteCommand extends ModelCommand {
+public class DeleteCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "delete";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/EditCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/EditCommand.java
@@ -33,7 +33,7 @@ import seedu.rc4hdb.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends ModelCommand {
+public class EditCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "edit";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/FilterCommand.java
@@ -21,7 +21,7 @@ import seedu.rc4hdb.model.resident.predicates.AttributesMatchKeywordsPredicate;
  * Filters and lists all residents in resident book whose attributes are equal to any of the argument keywords.
  * Keyword matching is case sensitive.
  */
-public class FilterCommand extends ModelCommand {
+public class FilterCommand implements ModelCommand {
     public static final String COMMAND_WORD = "filter";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": "
             + "filters the resident book by the attributes specified in the command"

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/FindCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/FindCommand.java
@@ -11,7 +11,7 @@ import seedu.rc4hdb.model.resident.predicates.NameContainsKeywordsPredicate;
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
  * Keyword matching is case-insensitive.
  */
-public class FindCommand extends ModelCommand {
+public class FindCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "find";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ListCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ListCommand.java
@@ -12,7 +12,7 @@ import seedu.rc4hdb.model.Model;
 /**
  * Lists all persons in the address book to the user.
  */
-public class ListCommand extends ModelCommand {
+public class ListCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "list";
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ModelCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ModelCommand.java
@@ -8,7 +8,7 @@ import seedu.rc4hdb.model.Model;
 /**
  * Represents a command that interacts with a {@code Model}.
  */
-public abstract class ModelCommand extends Command {
+public interface ModelCommand extends Command {
 
     /**
      * Executes the command and returns the result message.
@@ -17,6 +17,6 @@ public abstract class ModelCommand extends Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model) throws CommandException;
+    CommandResult execute(Model model) throws CommandException;
 
 }

--- a/src/main/java/seedu/rc4hdb/logic/commands/storagecommands/StorageCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/storagecommands/StorageCommand.java
@@ -8,7 +8,7 @@ import seedu.rc4hdb.storage.Storage;
 /**
  * Represents a command that interacts with a {@code Storage}.
  */
-public abstract class StorageCommand extends Command {
+public interface StorageCommand extends Command {
 
     /**
      * Executes the command and returns the result message.
@@ -17,6 +17,6 @@ public abstract class StorageCommand extends Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Storage storage) throws CommandException;
+    CommandResult execute(Storage storage) throws CommandException;
 
 }


### PR DESCRIPTION
Currently, the `Command` class makes use of Java abstract classes. By converting `Command` and other abstract `Command` subclasses into Java interfaces, we achieve greater flexibility in organizing our `Command` classes.

## Approval:
- [ ] Alvin
- [x] Jordan
- [x] Naren
- [x] Neale
- [ ] Nicholas