### PR TITLE
Refactor list command into show and hide commands

### DIFF
--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
@@ -14,7 +14,7 @@ public class HideCommand implements ModelCommand {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Hides the table columns according to the fields\n"
             + "specified (case-insensitive) after the command word\n"
             + "Parameters: FIELD [MORE_FIELDS]...\n"
-            + "Example: " + COMMAND_WORD + " gender room matric";
+            + "Example: " + COMMAND_WORD + " room gender matric";
 
     public static final String MESSAGE_SUCCESS = "Showing only the specified columns";
 
@@ -46,5 +46,4 @@ public class HideCommand implements ModelCommand {
         }
         return false;
     }
-
 }

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
@@ -16,7 +16,8 @@ public class HideCommand implements ModelCommand {
             + "Parameters: FIELD [MORE_FIELDS]...\n"
             + "Example: " + COMMAND_WORD + " room gender matric";
 
-    public static final String MESSAGE_SUCCESS = "Showing only the specified columns";
+    public static final String MESSAGE_SUCCESS = "Hidden some columns from the table view. "
+            + "Use the list command to restore all columns.";
 
     private final List<String> fieldsToShow;
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
@@ -1,12 +1,15 @@
 package seedu.rc4hdb.logic.commands.modelcommands;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 
-import static java.util.Objects.requireNonNull;
 import seedu.rc4hdb.logic.commands.CommandResult;
 import seedu.rc4hdb.model.Model;
-import static seedu.rc4hdb.model.Model.PREDICATE_SHOW_ALL_RESIDENTS;
 
+/**
+ * Updates the table view by hiding the columns specified by the user.
+ */
 public class HideCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "hide";
@@ -19,22 +22,40 @@ public class HideCommand implements ModelCommand {
     public static final String MESSAGE_SUCCESS = "Hidden some columns from the table view. "
             + "Use the list command to restore all columns.";
 
-    private final List<String> fieldsToShow;
+    /**
+     * The list of fields to pass to the TableView for hiding.
+     */
+    private final List<String> fieldsToHide;
 
-    public HideCommand(List<String> fieldsToShow) {
-        requireNonNull(fieldsToShow);
-        this.fieldsToShow = fieldsToShow;
+    /**
+     * Constructor for a HideCommand instance.
+     * @param fieldsToHide The list of fields to hide in the table
+     */
+    public HideCommand(List<String> fieldsToHide) {
+        requireNonNull(fieldsToHide);
+        this.fieldsToHide = fieldsToHide;
     }
 
+    /**
+     * Implements the execute method in the ModelCommand interface.
+     * The model field list is updated with the internal field list.
+     * @param model {@code Model} which the command should operate on.
+     * @return A CommandResult if the execution was successful.
+     */
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredResidentList(PREDICATE_SHOW_ALL_RESIDENTS);
-        model.setObservableFields(fieldsToShow);
+        model.setObservableFields(fieldsToHide);
 
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
+    /**
+     * Overrides the equals method in the Object class.
+     * Checks if the field lists have the same content.
+     * @param other The object to check for equality
+     * @return True if the object is equals to this instance
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -42,8 +63,8 @@ public class HideCommand implements ModelCommand {
         }
         if (other instanceof HideCommand) {
             HideCommand otherCommand = (HideCommand) other;
-            return this.fieldsToShow.containsAll(otherCommand.fieldsToShow)
-                    && otherCommand.fieldsToShow.containsAll(this.fieldsToShow);
+            return this.fieldsToHide.containsAll(otherCommand.fieldsToHide)
+                    && otherCommand.fieldsToHide.containsAll(this.fieldsToHide);
         }
         return false;
     }

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommand.java
@@ -1,0 +1,50 @@
+package seedu.rc4hdb.logic.commands.modelcommands;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import seedu.rc4hdb.logic.commands.CommandResult;
+import seedu.rc4hdb.model.Model;
+import static seedu.rc4hdb.model.Model.PREDICATE_SHOW_ALL_RESIDENTS;
+
+public class HideCommand implements ModelCommand {
+
+    public static final String COMMAND_WORD = "hide";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Hides the table columns according to the fields\n"
+            + "specified (case-insensitive) after the command word\n"
+            + "Parameters: FIELD [MORE_FIELDS]...\n"
+            + "Example: " + COMMAND_WORD + " gender room matric";
+
+    public static final String MESSAGE_SUCCESS = "Showing only the specified columns";
+
+    private final List<String> fieldsToShow;
+
+    public HideCommand(List<String> fieldsToShow) {
+        requireNonNull(fieldsToShow);
+        this.fieldsToShow = fieldsToShow;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredResidentList(PREDICATE_SHOW_ALL_RESIDENTS);
+        model.setObservableFields(fieldsToShow);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other instanceof HideCommand) {
+            HideCommand otherCommand = (HideCommand) other;
+            return this.fieldsToShow.containsAll(otherCommand.fieldsToShow)
+                    && otherCommand.fieldsToShow.containsAll(this.fieldsToShow);
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 import seedu.rc4hdb.logic.commands.CommandResult;
-import seedu.rc4hdb.logic.commands.exceptions.CommandException;
 import seedu.rc4hdb.model.Model;
 import static seedu.rc4hdb.model.Model.PREDICATE_SHOW_ALL_RESIDENTS;
 
@@ -17,7 +16,8 @@ public class ShowCommand implements ModelCommand {
             + "Parameters: FIELD [MORE_FIELDS]...\n"
             + "Example: " + COMMAND_WORD + " name phone email";
 
-    public static final String MESSAGE_SUCCESS = "Hidden some columns from the table view.";
+    public static final String MESSAGE_SUCCESS = "Showing only the specified columns. "
+            + "Use the list command to restore all columns.";
 
     public final List<String> fieldsToHide;
 

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
@@ -12,7 +12,7 @@ public class ShowCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "show";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Hides all columns according to the fields specified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows only the columns specified "
             + "(case-insensitive) after the command word\n"
             + "Parameters: FIELD [MORE_FIELDS]...\n"
             + "Example: " + COMMAND_WORD + " name phone email";
@@ -27,7 +27,7 @@ public class ShowCommand implements ModelCommand {
     }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredResidentList(PREDICATE_SHOW_ALL_RESIDENTS);
         model.setObservableFields(fieldsToHide);

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
@@ -1,12 +1,15 @@
 package seedu.rc4hdb.logic.commands.modelcommands;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.List;
 
-import static java.util.Objects.requireNonNull;
 import seedu.rc4hdb.logic.commands.CommandResult;
 import seedu.rc4hdb.model.Model;
-import static seedu.rc4hdb.model.Model.PREDICATE_SHOW_ALL_RESIDENTS;
 
+/**
+ * Updates the table view to show only the columns specified by the user.
+ */
 public class ShowCommand implements ModelCommand {
 
     public static final String COMMAND_WORD = "show";
@@ -19,22 +22,40 @@ public class ShowCommand implements ModelCommand {
     public static final String MESSAGE_SUCCESS = "Showing only the specified columns. "
             + "Use the list command to restore all columns.";
 
+    /**
+     * The list of fields to pass to the TableView for hiding.
+     */
     public final List<String> fieldsToHide;
 
+    /**
+     * Constructor for a ShowCommand instance.
+     * @param fieldsToHide The list of fields to hide in the table
+     */
     public ShowCommand(List<String> fieldsToHide) {
         requireNonNull(fieldsToHide);
         this.fieldsToHide = fieldsToHide;
     }
 
+    /**
+     * Implements the execute method in the ModelCommand interface.
+     * The model field list is updated with the internal field list.
+     * @param model {@code Model} which the command should operate on.
+     * @return A CommandResult if the execution was successful.
+     */
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredResidentList(PREDICATE_SHOW_ALL_RESIDENTS);
         model.setObservableFields(fieldsToHide);
 
         return new CommandResult(MESSAGE_SUCCESS);
     }
 
+    /**
+     * Overrides the equals method in the Object class.
+     * Checks if the field lists have the same content.
+     * @param other The object to check for equality
+     * @return True if the object is equals to this instance
+     */
     @Override
     public boolean equals(Object other) {
         if (other == this) {

--- a/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
+++ b/src/main/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommand.java
@@ -1,0 +1,50 @@
+package seedu.rc4hdb.logic.commands.modelcommands;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+import seedu.rc4hdb.logic.commands.CommandResult;
+import seedu.rc4hdb.logic.commands.exceptions.CommandException;
+import seedu.rc4hdb.model.Model;
+import static seedu.rc4hdb.model.Model.PREDICATE_SHOW_ALL_RESIDENTS;
+
+public class ShowCommand implements ModelCommand {
+
+    public static final String COMMAND_WORD = "show";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Hides all columns according to the fields specified "
+            + "(case-insensitive) after the command word\n"
+            + "Parameters: FIELD [MORE_FIELDS]...\n"
+            + "Example: " + COMMAND_WORD + " name phone email";
+
+    public static final String MESSAGE_SUCCESS = "Hidden some columns from the table view.";
+
+    public final List<String> fieldsToHide;
+
+    public ShowCommand(List<String> fieldsToHide) {
+        requireNonNull(fieldsToHide);
+        this.fieldsToHide = fieldsToHide;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        model.updateFilteredResidentList(PREDICATE_SHOW_ALL_RESIDENTS);
+        model.setObservableFields(fieldsToHide);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+        if (other instanceof ShowCommand) {
+            ShowCommand otherCommand = (ShowCommand) other;
+            return this.fieldsToHide.containsAll(otherCommand.fieldsToHide)
+                    && otherCommand.fieldsToHide.containsAll(this.fieldsToHide);
+        }
+        return false;
+    }
+}

--- a/src/main/java/seedu/rc4hdb/logic/parser/ResidentBookParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/ResidentBookParser.java
@@ -3,16 +3,31 @@ package seedu.rc4hdb.logic.parser;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.rc4hdb.logic.commands.Command;
 import seedu.rc4hdb.logic.commands.misccommands.ExitCommand;
 import seedu.rc4hdb.logic.commands.misccommands.HelpCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.*;
+import seedu.rc4hdb.logic.commands.modelcommands.AddCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ClearCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.DeleteCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.EditCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.FilterCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.FindCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ListCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
 import seedu.rc4hdb.logic.commands.storagecommands.filecommands.FileCommand;
-import seedu.rc4hdb.logic.parser.commandparsers.*;
+import seedu.rc4hdb.logic.parser.commandparsers.AddCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.DeleteCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.EditCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.FileCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.FilterCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.FindCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.HideCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.ListCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.ShowCommandParser;
 import seedu.rc4hdb.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/rc4hdb/logic/parser/ResidentBookParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/ResidentBookParser.java
@@ -3,27 +3,16 @@ package seedu.rc4hdb.logic.parser;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.rc4hdb.logic.commands.Command;
 import seedu.rc4hdb.logic.commands.misccommands.ExitCommand;
 import seedu.rc4hdb.logic.commands.misccommands.HelpCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.AddCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.ClearCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.DeleteCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.EditCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.FilterCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.FindCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.ListCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.*;
 import seedu.rc4hdb.logic.commands.storagecommands.filecommands.FileCommand;
-import seedu.rc4hdb.logic.parser.commandparsers.AddCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.DeleteCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.EditCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.FileCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.FilterCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.FindCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.ListCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.*;
 import seedu.rc4hdb.logic.parser.exceptions.ParseException;
 
 /**
@@ -77,11 +66,17 @@ public class ResidentBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
+        case HideCommand.COMMAND_WORD:
+            return new HideCommandParser().parse(arguments);
+
         case FilterCommand.COMMAND_WORD:
             return new FilterCommandParser().parse(arguments);
 
         case FileCommand.COMMAND_WORD:
             return new FileCommandParser().parse(arguments);
+
+        case ShowCommand.COMMAND_WORD:
+            return new ShowCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
@@ -1,15 +1,19 @@
 package seedu.rc4hdb.logic.parser.commandparsers;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.requireNonNull;
 import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
 import seedu.rc4hdb.logic.parser.Parser;
 import seedu.rc4hdb.logic.parser.exceptions.ParseException;
 import seedu.rc4hdb.model.resident.fields.ResidentFields;
 
+/**
+ * Parses input arguments and creates a new HideCommand object.
+ */
 public class HideCommandParser implements Parser<HideCommand> {
 
     public static final String INTENDED_USAGE = "Please (only) enter some fields after the hide command\n"
@@ -18,6 +22,12 @@ public class HideCommandParser implements Parser<HideCommand> {
     public static final String ERROR_MESSAGE = "Please only specify fields that correspond to resident data, "
             + "or check if you have made a typo.";
 
+    /**
+     * Implements the parse method in the Parser interface.
+     * @param args The arguments read from the user
+     * @return A HideCommand with the list of fields to hide
+     * @throws ParseException if the arguments have invalid inputs
+     */
     @Override
     public HideCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -30,13 +40,13 @@ public class HideCommandParser implements Parser<HideCommand> {
         List<String> allFields = ResidentFields.FIELDS.stream().map(String::toLowerCase).collect(Collectors.toList());
 
         // Create result list
-        List<String> fieldsToInclude = new ArrayList<>();
+        List<String> fieldsToHide = new ArrayList<>();
 
         String[] specifiedFields = getSpecifiedFields(args);
 
-        populateFieldLists(specifiedFields, fieldsToInclude, allFields);
+        populateFieldLists(specifiedFields, fieldsToHide, allFields);
 
-        return new HideCommand(fieldsToInclude);
+        return new HideCommand(fieldsToHide);
     }
 
     private String[] getSpecifiedFields(String args) {
@@ -44,13 +54,13 @@ public class HideCommandParser implements Parser<HideCommand> {
     }
 
     private void populateFieldLists(String[] specifiedFields,
-                                    List<String> fieldsToInclude,
+                                    List<String> fieldsToHide,
                                     List<String> allFields) throws ParseException {
         for (String field : specifiedFields) {
             if (!allFields.contains(field)) {
                 throw new ParseException(ERROR_MESSAGE);
             }
-            fieldsToInclude.add(field);
+            fieldsToHide.add(field);
         }
     }
 }

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
@@ -1,0 +1,50 @@
+package seedu.rc4hdb.logic.parser.commandparsers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
+import seedu.rc4hdb.logic.parser.Parser;
+import seedu.rc4hdb.logic.parser.exceptions.ParseException;
+import seedu.rc4hdb.model.resident.fields.ResidentFields;
+
+public class HideCommandParser implements Parser<HideCommand> {
+
+    public static final String INTENDED_USAGE = "Please (only) enter some fields after the hide command\n"
+            + "Example: hide room gender matric";
+
+    @Override
+    public HideCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        if (args.isEmpty()) {
+            throw new ParseException(INTENDED_USAGE);
+        }
+
+        // Process global list of fields into lowercase list first
+        List<String> allFields = ResidentFields.FIELDS.stream().map(String::toLowerCase).collect(Collectors.toList());
+
+        // Create result list
+        List<String> fieldsToInclude = new ArrayList<>(allFields);
+
+        String[] specifiedFields = getSpecifiedFields(args);
+
+        populateFieldLists(specifiedFields, fieldsToInclude, allFields);
+
+        return new HideCommand(fieldsToInclude);
+    }
+
+    private String[] getSpecifiedFields(String args) {
+        return args.trim().toLowerCase().split(" ");
+    }
+
+    private void populateFieldLists(String[] specifiedFields, List<String> fieldsToInclude, List<String> allFields) {
+        for (String field : specifiedFields) {
+            if (allFields.contains(field)) {
+                fieldsToInclude.add(field);
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
@@ -22,6 +24,8 @@ public class HideCommandParser implements Parser<HideCommand> {
     public static final String ERROR_MESSAGE = "Please only specify fields that correspond to resident data, "
             + "or check if you have made a typo.";
 
+    private static Logger logger = Logger.getLogger("HideCommandParser");
+
     /**
      * Implements the parse method in the Parser interface.
      * @param args The arguments read from the user
@@ -31,8 +35,10 @@ public class HideCommandParser implements Parser<HideCommand> {
     @Override
     public HideCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        logger.log(Level.INFO, "Going to start parsing.");
 
         if (args.isEmpty()) {
+            logger.log(Level.WARNING, "Empty arguments when parsing.");
             throw new ParseException(INTENDED_USAGE);
         }
 
@@ -46,6 +52,7 @@ public class HideCommandParser implements Parser<HideCommand> {
 
         populateFieldLists(specifiedFields, fieldsToHide, allFields);
 
+        logger.log(Level.INFO, "Parsing completed, returning HideCommand");
         return new HideCommand(fieldsToHide);
     }
 

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
@@ -15,6 +15,9 @@ public class HideCommandParser implements Parser<HideCommand> {
     public static final String INTENDED_USAGE = "Please (only) enter some fields after the hide command\n"
             + "Example: hide room gender matric";
 
+    public static final String ERROR_MESSAGE = "Please only specify fields that correspond to resident data, "
+            + "or check if you have made a typo.";
+
     @Override
     public HideCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -40,11 +43,14 @@ public class HideCommandParser implements Parser<HideCommand> {
         return args.trim().toLowerCase().split(" ");
     }
 
-    private void populateFieldLists(String[] specifiedFields, List<String> fieldsToInclude, List<String> allFields) {
+    private void populateFieldLists(String[] specifiedFields,
+                                    List<String> fieldsToInclude,
+                                    List<String> allFields) throws ParseException {
         for (String field : specifiedFields) {
-            if (allFields.contains(field)) {
-                fieldsToInclude.add(field);
+            if (!allFields.contains(field)) {
+                throw new ParseException(ERROR_MESSAGE);
             }
+            fieldsToInclude.add(field);
         }
     }
 }

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParser.java
@@ -27,7 +27,7 @@ public class HideCommandParser implements Parser<HideCommand> {
         List<String> allFields = ResidentFields.FIELDS.stream().map(String::toLowerCase).collect(Collectors.toList());
 
         // Create result list
-        List<String> fieldsToInclude = new ArrayList<>(allFields);
+        List<String> fieldsToInclude = new ArrayList<>();
 
         String[] specifiedFields = getSpecifiedFields(args);
 

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.rc4hdb.logic.parser.commandparsers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
+import seedu.rc4hdb.logic.parser.Parser;
+import seedu.rc4hdb.logic.parser.exceptions.ParseException;
+import seedu.rc4hdb.model.resident.fields.ResidentFields;
+
+public class ShowCommandParser implements Parser<ShowCommand> {
+
+    public static final String INTENDED_USAGE = "Please enter some fields after the show command\n"
+            + "Example: show name phone email";
+
+    @Override
+    public ShowCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        if (args.isEmpty()) {
+            throw new ParseException(INTENDED_USAGE);
+        }
+
+        // Process global list of fields into lowercase list first
+        List<String> allFields = ResidentFields.FIELDS.stream().map(String::toLowerCase).collect(Collectors.toList());
+
+        // Create result list
+        List<String> fieldsToExclude = new ArrayList<>(allFields);
+
+        String[] specifiedFields = getSpecifiedFields(args);
+
+        populateFieldLists(specifiedFields, fieldsToExclude);
+
+        return new ShowCommand(fieldsToExclude);
+    }
+
+    private String[] getSpecifiedFields(String args) {
+        return args.trim().toLowerCase().split(" ");
+    }
+
+    private void populateFieldLists(String[] specifiedFields, List<String> fieldsToExclude) {
+        for (String field : specifiedFields) {
+            fieldsToExclude.remove(field);
+        }
+    }
+}

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
@@ -1,15 +1,19 @@
 package seedu.rc4hdb.logic.parser.commandparsers;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static java.util.Objects.requireNonNull;
 import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
 import seedu.rc4hdb.logic.parser.Parser;
 import seedu.rc4hdb.logic.parser.exceptions.ParseException;
 import seedu.rc4hdb.model.resident.fields.ResidentFields;
 
+/**
+ * Parses input arguments and creates a new ShowCommand object.
+ */
 public class ShowCommandParser implements Parser<ShowCommand> {
 
     public static final String INTENDED_USAGE = "Please (only) enter some fields after the show command\n"
@@ -18,6 +22,12 @@ public class ShowCommandParser implements Parser<ShowCommand> {
     public static final String ERROR_MESSAGE = "Please only specify fields that correspond to resident data, "
             + "or check if you have made a typo.";
 
+    /**
+     * Implements the parse method in the Parser interface.
+     * @param args The arguments read from the user
+     * @return A ShowCommand with the list of fields to hide
+     * @throws ParseException if the arguments have invalid inputs
+     */
     @Override
     public ShowCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -30,13 +40,13 @@ public class ShowCommandParser implements Parser<ShowCommand> {
         List<String> allFields = ResidentFields.FIELDS.stream().map(String::toLowerCase).collect(Collectors.toList());
 
         // Create result list
-        List<String> fieldsToExclude = new ArrayList<>(allFields);
+        List<String> fieldsToHide = new ArrayList<>(allFields);
 
         String[] specifiedFields = getSpecifiedFields(args);
 
-        populateFieldLists(specifiedFields, fieldsToExclude, allFields);
+        populateFieldLists(specifiedFields, fieldsToHide, allFields);
 
-        return new ShowCommand(fieldsToExclude);
+        return new ShowCommand(fieldsToHide);
     }
 
     private String[] getSpecifiedFields(String args) {
@@ -44,13 +54,13 @@ public class ShowCommandParser implements Parser<ShowCommand> {
     }
 
     private void populateFieldLists(String[] specifiedFields,
-                                    List<String> fieldsToExclude,
+                                    List<String> fieldsToHide,
                                     List<String> allFields) throws ParseException {
         for (String field : specifiedFields) {
             if (!allFields.contains(field)) {
                 throw new ParseException(ERROR_MESSAGE);
             }
-            fieldsToExclude.remove(field);
+            fieldsToHide.remove(field);
         }
     }
 }

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
@@ -22,6 +24,8 @@ public class ShowCommandParser implements Parser<ShowCommand> {
     public static final String ERROR_MESSAGE = "Please only specify fields that correspond to resident data, "
             + "or check if you have made a typo.";
 
+    private static Logger logger = Logger.getLogger("ShowCommandParser");
+
     /**
      * Implements the parse method in the Parser interface.
      * @param args The arguments read from the user
@@ -31,8 +35,10 @@ public class ShowCommandParser implements Parser<ShowCommand> {
     @Override
     public ShowCommand parse(String args) throws ParseException {
         requireNonNull(args);
+        logger.log(Level.INFO, "Going to start parsing.");
 
         if (args.isEmpty()) {
+            logger.log(Level.WARNING, "Empty arguments when parsing.");
             throw new ParseException(INTENDED_USAGE);
         }
 
@@ -46,6 +52,7 @@ public class ShowCommandParser implements Parser<ShowCommand> {
 
         populateFieldLists(specifiedFields, fieldsToHide, allFields);
 
+        logger.log(Level.INFO, "Parsing completed, returning ShowCommand");
         return new ShowCommand(fieldsToHide);
     }
 

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
@@ -12,7 +12,7 @@ import seedu.rc4hdb.model.resident.fields.ResidentFields;
 
 public class ShowCommandParser implements Parser<ShowCommand> {
 
-    public static final String INTENDED_USAGE = "Please enter some fields after the show command\n"
+    public static final String INTENDED_USAGE = "Please (only) enter some fields after the show command\n"
             + "Example: show name phone email";
 
     @Override

--- a/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
+++ b/src/main/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParser.java
@@ -15,6 +15,9 @@ public class ShowCommandParser implements Parser<ShowCommand> {
     public static final String INTENDED_USAGE = "Please (only) enter some fields after the show command\n"
             + "Example: show name phone email";
 
+    public static final String ERROR_MESSAGE = "Please only specify fields that correspond to resident data, "
+            + "or check if you have made a typo.";
+
     @Override
     public ShowCommand parse(String args) throws ParseException {
         requireNonNull(args);
@@ -31,7 +34,7 @@ public class ShowCommandParser implements Parser<ShowCommand> {
 
         String[] specifiedFields = getSpecifiedFields(args);
 
-        populateFieldLists(specifiedFields, fieldsToExclude);
+        populateFieldLists(specifiedFields, fieldsToExclude, allFields);
 
         return new ShowCommand(fieldsToExclude);
     }
@@ -40,8 +43,13 @@ public class ShowCommandParser implements Parser<ShowCommand> {
         return args.trim().toLowerCase().split(" ");
     }
 
-    private void populateFieldLists(String[] specifiedFields, List<String> fieldsToExclude) {
+    private void populateFieldLists(String[] specifiedFields,
+                                    List<String> fieldsToExclude,
+                                    List<String> allFields) throws ParseException {
         for (String field : specifiedFields) {
+            if (!allFields.contains(field)) {
+                throw new ParseException(ERROR_MESSAGE);
+            }
             fieldsToExclude.remove(field);
         }
     }

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommandTest.java
@@ -1,0 +1,50 @@
+package seedu.rc4hdb.logic.commands.modelcommands;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
+import seedu.rc4hdb.model.Model;
+import seedu.rc4hdb.model.ModelManager;
+import seedu.rc4hdb.model.UserPrefs;
+import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
+
+public class HideCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalResidentBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getResidentBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_hideCommandWithNonEmptyList_hideNonEmptyListInModel() {
+        expectedModel.setObservableFields(List.of("room", "gender"));
+        assertCommandSuccess(new HideCommand(List.of("room", "gender")), model, HideCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_showCommandWithEmptyList_overwritesNonEmptyListInModel() {
+        model.setObservableFields(List.of("room", "gender"));
+
+        // already empty during initialisation but added to make test case explicit
+        expectedModel.setObservableFields(List.of());
+
+        assertCommandSuccess(new HideCommand(List.of()), model, HideCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_showCommandWithNonEmptyList_overwritesEmptyListInModel() {
+        // already empty during initialisation but added to make test case explicit
+        model.setObservableFields(List.of());
+
+        expectedModel.setObservableFields(List.of("room", "gender"));
+
+        assertCommandSuccess(new HideCommand(List.of("room", "gender")), model, HideCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/HideCommandTest.java
@@ -1,14 +1,16 @@
 package seedu.rc4hdb.logic.commands.modelcommands;
 
+import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
+import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
+
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
+
 import seedu.rc4hdb.model.Model;
 import seedu.rc4hdb.model.ModelManager;
 import seedu.rc4hdb.model.UserPrefs;
-import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
 
 public class HideCommandTest {
 
@@ -24,7 +26,8 @@ public class HideCommandTest {
     @Test
     public void execute_hideCommandWithNonEmptyList_hideNonEmptyListInModel() {
         expectedModel.setObservableFields(List.of("room", "gender"));
-        assertCommandSuccess(new HideCommand(List.of("room", "gender")), model, HideCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new HideCommand(List.of("room", "gender")), model,
+                HideCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -44,7 +47,8 @@ public class HideCommandTest {
 
         expectedModel.setObservableFields(List.of("room", "gender"));
 
-        assertCommandSuccess(new HideCommand(List.of("room", "gender")), model, HideCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new HideCommand(List.of("room", "gender")), model,
+                HideCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
 }

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommandTest.java
@@ -1,0 +1,49 @@
+package seedu.rc4hdb.logic.commands.modelcommands;
+
+import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.rc4hdb.model.Model;
+import seedu.rc4hdb.model.ModelManager;
+import seedu.rc4hdb.model.UserPrefs;
+import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
+
+public class ShowCommandTest {
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalResidentBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getResidentBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_showCommandWithNonEmptyList_showsNonEmptyListInModel() {
+        expectedModel.setObservableFields(List.of("name", "phone"));
+        assertCommandSuccess(new ShowCommand(List.of("name", "phone")), model, ShowCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_showCommandWithEmptyList_overwritesNonEmptyListInModel() {
+        model.setObservableFields(List.of("name", "phone"));
+
+        // already empty during initialisation but added to make test case explicit
+        expectedModel.setObservableFields(List.of());
+
+        assertCommandSuccess(new ShowCommand(List.of()), model, ShowCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_showCommandWithNonEmptyList_overwritesEmptyListInModel() {
+        // already empty during initialisation but added to make test case explicit
+        model.setObservableFields(List.of());
+
+        expectedModel.setObservableFields(List.of("name", "phone"));
+
+        assertCommandSuccess(new ShowCommand(List.of("name", "phone")), model, ShowCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommandTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/commands/modelcommands/ShowCommandTest.java
@@ -1,15 +1,16 @@
 package seedu.rc4hdb.logic.commands.modelcommands;
 
 import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.assertCommandSuccess;
+import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
 
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.rc4hdb.model.Model;
 import seedu.rc4hdb.model.ModelManager;
 import seedu.rc4hdb.model.UserPrefs;
-import static seedu.rc4hdb.testutil.TypicalResidents.getTypicalResidentBook;
 
 public class ShowCommandTest {
     private Model model;
@@ -24,7 +25,8 @@ public class ShowCommandTest {
     @Test
     public void execute_showCommandWithNonEmptyList_showsNonEmptyListInModel() {
         expectedModel.setObservableFields(List.of("name", "phone"));
-        assertCommandSuccess(new ShowCommand(List.of("name", "phone")), model, ShowCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ShowCommand(List.of("name", "phone")), model,
+                ShowCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
@@ -44,6 +46,7 @@ public class ShowCommandTest {
 
         expectedModel.setObservableFields(List.of("name", "phone"));
 
-        assertCommandSuccess(new ShowCommand(List.of("name", "phone")), model, ShowCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ShowCommand(List.of("name", "phone")), model,
+                ShowCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/rc4hdb/logic/parser/ResidentBookParserTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/parser/ResidentBookParserTest.java
@@ -1,14 +1,12 @@
 package seedu.rc4hdb.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import seedu.rc4hdb.logic.commands.modelcommands.*;
 import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.NAME_DESC_AMY;
 import static seedu.rc4hdb.logic.commands.storagecommands.StorageCommandTestUtil.VALID_FILE_NAME_PATH;
 import static seedu.rc4hdb.logic.commands.storagecommands.StorageCommandTestUtil.VALID_FILE_NAME_STRING;
-import seedu.rc4hdb.logic.parser.commandparsers.HideCommandParser;
-import seedu.rc4hdb.logic.parser.commandparsers.ShowCommandParser;
 import static seedu.rc4hdb.testutil.Assert.assertThrows;
 import static seedu.rc4hdb.testutil.TypicalIndexes.INDEX_FIRST_RESIDENT;
 
@@ -20,9 +18,20 @@ import org.junit.jupiter.api.Test;
 
 import seedu.rc4hdb.logic.commands.misccommands.ExitCommand;
 import seedu.rc4hdb.logic.commands.misccommands.HelpCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.AddCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ClearCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.DeleteCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.EditCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.FilterCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.FindCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ListCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
 import seedu.rc4hdb.logic.commands.storagecommands.filecommands.FileCommand;
 import seedu.rc4hdb.logic.commands.storagecommands.filecommands.FileCreateCommand;
+import seedu.rc4hdb.logic.parser.commandparsers.HideCommandParser;
 import seedu.rc4hdb.logic.parser.commandparsers.ListCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.ShowCommandParser;
 import seedu.rc4hdb.logic.parser.exceptions.ParseException;
 import seedu.rc4hdb.model.resident.Resident;
 import seedu.rc4hdb.model.resident.ResidentDescriptor;

--- a/src/test/java/seedu/rc4hdb/logic/parser/ResidentBookParserTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/parser/ResidentBookParserTest.java
@@ -1,12 +1,14 @@
 package seedu.rc4hdb.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.rc4hdb.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import seedu.rc4hdb.logic.commands.modelcommands.*;
 import static seedu.rc4hdb.logic.commands.modelcommands.ModelCommandTestUtil.NAME_DESC_AMY;
 import static seedu.rc4hdb.logic.commands.storagecommands.StorageCommandTestUtil.VALID_FILE_NAME_PATH;
 import static seedu.rc4hdb.logic.commands.storagecommands.StorageCommandTestUtil.VALID_FILE_NAME_STRING;
+import seedu.rc4hdb.logic.parser.commandparsers.HideCommandParser;
+import seedu.rc4hdb.logic.parser.commandparsers.ShowCommandParser;
 import static seedu.rc4hdb.testutil.Assert.assertThrows;
 import static seedu.rc4hdb.testutil.TypicalIndexes.INDEX_FIRST_RESIDENT;
 
@@ -18,13 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.rc4hdb.logic.commands.misccommands.ExitCommand;
 import seedu.rc4hdb.logic.commands.misccommands.HelpCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.AddCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.ClearCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.DeleteCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.EditCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.FilterCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.FindCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.ListCommand;
 import seedu.rc4hdb.logic.commands.storagecommands.filecommands.FileCommand;
 import seedu.rc4hdb.logic.commands.storagecommands.filecommands.FileCreateCommand;
 import seedu.rc4hdb.logic.parser.commandparsers.ListCommandParser;
@@ -90,6 +85,15 @@ public class ResidentBookParserTest {
     }
 
     @Test
+    public void parseCommand_hide() throws Exception {
+        assertThrows(ParseException.class, String.format(HideCommandParser.INTENDED_USAGE), ()
+                -> parser.parseCommand(HideCommand.COMMAND_WORD));
+        assertThrows(ParseException.class, String.format(HideCommandParser.ERROR_MESSAGE), ()
+                -> parser.parseCommand(HideCommand.COMMAND_WORD + " jibbitz"));
+        assertTrue(parser.parseCommand(HideCommand.COMMAND_WORD + " name phone email") instanceof HideCommand);
+    }
+
+    @Test
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertThrows(ParseException.class, String.format(ListCommandParser.INTENDED_USAGE), ()
@@ -113,6 +117,15 @@ public class ResidentBookParserTest {
         FileCommand fileCommand = (FileCommand) parser.parseCommand(FileCommand.COMMAND_WORD
                 + " " + FileCreateCommand.COMMAND_WORD + " " + VALID_FILE_NAME_STRING);
         assertEquals(new FileCreateCommand(VALID_FILE_NAME_PATH), fileCommand);
+    }
+
+    @Test
+    public void parseCommand_show() throws Exception {
+        assertThrows(ParseException.class, String.format(ShowCommandParser.INTENDED_USAGE), ()
+                -> parser.parseCommand(ShowCommand.COMMAND_WORD));
+        assertThrows(ParseException.class, String.format(ShowCommandParser.ERROR_MESSAGE), ()
+                -> parser.parseCommand(HideCommand.COMMAND_WORD + " crocs with socks"));
+        assertTrue(parser.parseCommand(ShowCommand.COMMAND_WORD + " room gender") instanceof ShowCommand);
     }
 
     @Test

--- a/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParserTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParserTest.java
@@ -1,14 +1,15 @@
 package seedu.rc4hdb.logic.parser.commandparsers;
 
+import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseFailure;
+import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseSuccess;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
-import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
-import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseFailure;
-import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseSuccess;
 import seedu.rc4hdb.model.resident.fields.ResidentFields;
 
 public class HideCommandParserTest {

--- a/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParserTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/HideCommandParserTest.java
@@ -1,0 +1,58 @@
+package seedu.rc4hdb.logic.parser.commandparsers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import seedu.rc4hdb.logic.commands.modelcommands.HideCommand;
+import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
+import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseFailure;
+import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseSuccess;
+import seedu.rc4hdb.model.resident.fields.ResidentFields;
+
+public class HideCommandParserTest {
+    private final HideCommandParser parser = new HideCommandParser();
+    private final List<String> emptyList = new ArrayList<>();
+    private final List<String> allFields = ResidentFields.FIELDS.stream()
+            .map(String::toLowerCase).collect(Collectors.toList());
+
+    @Test
+    public void parse_emptyArguments_throwsParseException() {
+        assertParseFailure(parser, "", HideCommandParser.INTENDED_USAGE);
+    }
+
+    @Test
+    public void parse_lowerCaseFields_returnsHideCommand() {
+        HideCommand expectedCommand = new HideCommand(List.of("name", "phone"));
+        assertParseSuccess(parser, "name phone", expectedCommand);
+    }
+
+    @Test
+    public void parse_mixedCaseFields_returnsShowCommand() {
+        HideCommand expectedCommand = new HideCommand(List.of("name", "phone"));
+        assertParseSuccess(parser, "nAmE pHoNe", expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidFields_throwsParseException() {
+        assertParseFailure(parser, "height weight", ShowCommandParser.ERROR_MESSAGE);
+    }
+
+    @Test
+    public void parse_validFieldsWithSpecifiers_throwsParseException() {
+        assertParseFailure(parser, "/all name phone", ShowCommandParser.ERROR_MESSAGE);
+    }
+
+    @Test
+    public void parse_duplicateFields_returnsCommand() {
+        HideCommand expectedCommand = new HideCommand(List.of("email"));
+        assertParseSuccess(parser, "email email", expectedCommand);
+    }
+
+    @Test
+    public void parse_allFields_returnsHideCommandWithEmptyList() {
+        HideCommand expectedCommand = new HideCommand(allFields);
+        assertParseSuccess(parser, "index name phone email room gender house matric tags", expectedCommand);
+    }
+}

--- a/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParserTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParserTest.java
@@ -1,6 +1,5 @@
 package seedu.rc4hdb.logic.parser.commandparsers;
 
-import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
 import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseFailure;
 import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,6 +8,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
+
+import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
 import seedu.rc4hdb.model.resident.fields.ResidentFields;
 
 public class ShowCommandParserTest {

--- a/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParserTest.java
+++ b/src/test/java/seedu/rc4hdb/logic/parser/commandparsers/ShowCommandParserTest.java
@@ -1,0 +1,65 @@
+package seedu.rc4hdb.logic.parser.commandparsers;
+
+import seedu.rc4hdb.logic.commands.modelcommands.ShowCommand;
+import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseFailure;
+import static seedu.rc4hdb.logic.parser.commandparsers.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import seedu.rc4hdb.model.resident.fields.ResidentFields;
+
+public class ShowCommandParserTest {
+    private final ShowCommandParser parser = new ShowCommandParser();
+    private final List<String> emptyList = new ArrayList<>();
+    private final List<String> allFields = ResidentFields.FIELDS.stream()
+            .map(String::toLowerCase).collect(Collectors.toList());
+
+    @Test
+    public void parse_emptyArguments_throwsParseException() {
+        assertParseFailure(parser, "", ShowCommandParser.INTENDED_USAGE);
+    }
+
+    @Test
+    public void parse_lowerCaseFields_returnsShowCommand() {
+        List<String> fieldsToHide = new ArrayList<>(allFields);
+        fieldsToHide.removeAll(List.of("name", "phone"));
+        ShowCommand expectedCommand = new ShowCommand(fieldsToHide);
+        assertParseSuccess(parser, "name phone", expectedCommand);
+    }
+
+    @Test
+    public void parse_mixedCaseFields_returnsShowCommand() {
+        List<String> fieldsToHide = new ArrayList<>(allFields);
+        fieldsToHide.removeAll(List.of("name", "phone"));
+        ShowCommand expectedCommand = new ShowCommand(fieldsToHide);
+        assertParseSuccess(parser, "nAmE pHoNe", expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidFields_throwsParseException() {
+        assertParseFailure(parser, "height weight", ShowCommandParser.ERROR_MESSAGE);
+    }
+
+    @Test
+    public void parse_validFieldsWithSpecifiers_throwsParseException() {
+        assertParseFailure(parser, "/all name phone", ShowCommandParser.ERROR_MESSAGE);
+    }
+
+    @Test
+    public void parse_duplicateFields_returnsShowCommand() {
+        List<String> fieldsToHide = new ArrayList<>(allFields);
+        fieldsToHide.removeAll(List.of("email"));
+        ShowCommand expectedCommand = new ShowCommand(fieldsToHide);
+        assertParseSuccess(parser, "email email", expectedCommand);
+    }
+
+    @Test
+    public void parse_allFields_returnsShowCommandWithEmptyList() {
+        List<String> fieldsToHide = new ArrayList<>(emptyList);
+        ShowCommand expectedCommand = new ShowCommand(fieldsToHide);
+        assertParseSuccess(parser, "index name phone email room gender house matric tags", expectedCommand);
+    }
+}


### PR DESCRIPTION
### Changes made:
1. `show` has been added to represent `list /i`, and `hide` has been added to represent 'list /e`. More details on the old command format can be found in #76 . 
2. The `show` and `hide` commands are less permissive than their previous counterparts: users must enter valid fields for the showing/hiding to work. This was added to make the cause-and-effect of the commands more explicit.
3. Unit tests were added for the new/modified classes.

### Things to note:
1. The use of the name `fieldsToHide` is intentional, as the implementation within `ResidentTableView` involves hiding the `TableColumns` based on a list of fields (to hide).
2. The `list /i` and `list /e` commands have not been removed yet. We can remove them after this PR is approved. 😄 
3. I will be working on the next increment for this feature, i.e. to make `show` and `hide` depend on the previous `show` and `hide` commands. More information can be found #125 
4. I will update the documentation after the feature is complete (when point 2 has been implemented).