### PR TITLE
Fix storage issues and make list of bookings more accessible

### DIFF
--- a/src/main/java/seedu/rc4hdb/commons/util/FileUtil.java
+++ b/src/main/java/seedu/rc4hdb/commons/util/FileUtil.java
@@ -83,6 +83,7 @@ public class FileUtil {
      * Will create the file if it does not exist yet.
      */
     public static void writeToFile(Path file, String content) throws IOException {
+        createParentDirsOfFile(file);
         Files.write(file, content.getBytes(CHARSET));
     }
 

--- a/src/main/java/seedu/rc4hdb/model/Model.java
+++ b/src/main/java/seedu/rc4hdb/model/Model.java
@@ -153,5 +153,6 @@ public interface Model {
 
     ObservableList<Booking> getObservableBookings();
 
-    void setObservableBookings(List<Booking> modifiableBookings);
+    void setObservableBookings(VenueName venueName);
+
 }

--- a/src/main/java/seedu/rc4hdb/model/ModelManager.java
+++ b/src/main/java/seedu/rc4hdb/model/ModelManager.java
@@ -53,7 +53,12 @@ public class ModelManager implements Model {
 
         this.observableFieldList = FXCollections.observableArrayList();
         this.observableVenueList = FXCollections.observableArrayList();
-        this.observableBookingList = FXCollections.observableArrayList();
+
+        if (observableVenueList.isEmpty()) {
+            this.observableBookingList = FXCollections.observableArrayList();
+        } else {
+            this.observableBookingList = observableVenueList.get(0).getObservableBookings();
+        }
     }
 
     public ModelManager() {
@@ -240,9 +245,10 @@ public class ModelManager implements Model {
     public ObservableList<Booking> getObservableBookings() {
         return this.observableBookingList;
     }
+
     @Override
-    public void setObservableBookings(List<Booking> modifiableFields) {
-        this.observableBookingList.setAll(modifiableFields);
+    public void setObservableBookings(VenueName venueName) {
+        this.observableBookingList.setAll(venueBook.getBookings(venueName));
     }
 
 }

--- a/src/main/java/seedu/rc4hdb/model/VenueBook.java
+++ b/src/main/java/seedu/rc4hdb/model/VenueBook.java
@@ -116,8 +116,15 @@ public class VenueBook implements ReadOnlyVenueBook {
         // TODO: refine later
     }
 
+    //=========== Observable Booking List Accessors =============================================================
+
     public ObservableList<Venue> getVenueList() {
         return venues.asUnmodifiableObservableList();
+    }
+
+    public ObservableList<Booking> getBookings(VenueName venueName) {
+        requireNonNull(venueName);
+        return venues.getBookings(venueName);
     }
 
     @Override

--- a/src/main/java/seedu/rc4hdb/model/venues/UniqueVenueList.java
+++ b/src/main/java/seedu/rc4hdb/model/venues/UniqueVenueList.java
@@ -86,6 +86,14 @@ public class UniqueVenueList implements Iterable<Venue> {
         getVenueWithName(otherVenueName).removeBooking(bookingPeriod, bookedDay);
     }
 
+    /**
+     * Gets the unmodifiable list of bookings that are associated to the venue with {@code venueName}.
+     */
+    public ObservableList<Booking> getBookings(VenueName venueName) {
+        requireNonNull(venueName);
+        return getVenueWithName(venueName).getObservableBookings();
+    }
+
     public void setVenues(UniqueVenueList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
@@ -105,6 +113,7 @@ public class UniqueVenueList implements Iterable<Venue> {
     }
 
     private Venue getVenueWithName(VenueName venueName) throws VenueNotFoundException {
+        requireNonNull(venueName);
         for (Venue venue : internalList) {
             if (venue.isSameVenue(venueName)) {
                 return venue;

--- a/src/main/java/seedu/rc4hdb/model/venues/Venue.java
+++ b/src/main/java/seedu/rc4hdb/model/venues/Venue.java
@@ -2,6 +2,7 @@ package seedu.rc4hdb.model.venues;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,7 @@ public class Venue implements BookingField {
     public static final String MESSAGE_CONSTRAINTS =
             "Venue should only consist of: 'meeting' ";
 
-    private ObservableList<Booking> bookings = FXCollections.observableArrayList();
+    private List<Booking> bookings = new ArrayList<>();
     private final VenueName venueName;
 
     /**
@@ -42,7 +43,7 @@ public class Venue implements BookingField {
      */
     public Venue(List<Booking> bookings, VenueName venueName) {
         this(venueName);
-        this.bookings = FXCollections.observableArrayList(bookings);
+        this.bookings = bookings;
     }
 
     /**
@@ -111,7 +112,8 @@ public class Venue implements BookingField {
 
     public ObservableList<Booking> getObservableBookings() {
         clearExpiredBookings();
-        return this.bookings;
+        return FXCollections.unmodifiableObservableList(
+                FXCollections.observableArrayList(bookings));
     }
 
     public VenueName getVenueName() {

--- a/src/main/java/seedu/rc4hdb/storage/venuebook/JsonAdaptedVenue.java
+++ b/src/main/java/seedu/rc4hdb/storage/venuebook/JsonAdaptedVenue.java
@@ -7,8 +7,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import seedu.rc4hdb.commons.exceptions.IllegalValueException;
 import seedu.rc4hdb.model.venues.Venue;
 import seedu.rc4hdb.model.venues.VenueName;
@@ -54,7 +52,7 @@ public class JsonAdaptedVenue {
      * @throws IllegalValueException if there were any data constraints violated in the adapted venue.
      */
     public Venue toModelType() throws IllegalValueException {
-        final ObservableList<Booking> modelBookings = FXCollections.observableArrayList();
+        final List<Booking> modelBookings = new ArrayList<>();
         for (JsonAdaptedBooking booking : bookings) {
             modelBookings.add(booking.toModelType());
         }


### PR DESCRIPTION
I've made it so that the `ModelManager` tries to initialize with the first venue in the list, if there are no venues in the list, it will initialize with an empty `ObservableList<Booking>`. Also, I've added a method to get the set the contents of `ObservableList<Booking>`  to the list of bookings in a venue.

![image](https://user-images.githubusercontent.com/95712150/197581494-87331763-7441-4ef7-80a9-27a25b64712e.png)
