### PR TITLE
`BUG FIX` Empty venue list appears white

### DIFF
--- a/src/main/resources/view/VenueListView.fxml
+++ b/src/main/resources/view/VenueListView.fxml
@@ -17,6 +17,6 @@
             </Label>
          </children>
       </HBox>
-      <ListView fx:id="venueListView" style="-fx-background-color: #FFFFFF;" styleClass="pane-with-border" stylesheets="@DarkTheme.css" VBox.vgrow="ALWAYS" />
+      <ListView fx:id="venueListView" styleClass="pane-with-border" stylesheets="@DarkTheme.css" VBox.vgrow="ALWAYS" />
    </children>
 </VBox>


### PR DESCRIPTION
# Background
As mentioned in #288, the `VenueListView` Ui component does not properly render. This is due to the background CSS element of the `ListView` Ui component being set to `#FFFFFF`.

## Fix:
Removed the background CSS element that was setting the background to `#FFFFFF`.

### Initially:
![image](https://user-images.githubusercontent.com/95712150/199914451-8f3dc156-1409-4431-ae9d-c198f510c4ac.png)

### After fix:
![image](https://user-images.githubusercontent.com/95712150/199916234-ff210831-26c1-421f-88a2-29adc810ad02.png)

#### Note that the bug with the currently displayed venue header stating that the currently viewed venue is hall despite the venue list being empty, is fixed in #283 