### PR TITLE
`BUG FIX` Resident uniqueness not tied to email, phone, matric number, room

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -351,14 +351,17 @@ Deleted data can not be retrieved. Do use this command cautiously!
 
 `g/GENDER`
 * `M` or `F`
+* Not case-sensitive
 
 `h/HOUSE`
 * Represents the RC4 house that the resident is allocated to
 * Must be either `A`, `D`, `L`, `N`, `U`
 * `A` stands for **Aquila**, `D` stands for **Draco**, `L` for **Leo**, `N` for **Noctua**`U` for **Ursa**
+* Not case-sensitive
 
 `m/MATRIC_NUMBER`
 * Must be an uppercase `A`, followed by a **7**-digit non-negative integer and an uppercase alphabet. *i.e. `A0123456A`*
+* Not case-sensitive
 
 `t/TAG`
 * Represents any other key that could be used to identify a resident

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -336,13 +336,13 @@ Deleted data can not be retrieved. Do use this command cautiously!
 ### Format for resident fields
 
 `n/NAME`
-* Whitespaces are allowed *i.e. `n/Michael B. Jordan` is allowed*
+* Whitespaces are allowed *i.e. `Michael B. Jordan` is allowed*
 
 `p/PHONE_NUMBER`
 * Must be an **8**-digit non-negative integer
 
 `e/EMAIL`
-* Must follow the formatting for all standard emails *i.e. `e/Example@email.com` is accepted*
+* Must follow the formatting for all standard emails *i.e. `Example@email.com` is accepted*
 * Can be both valid or invalid emails
 
 `r/FLOOR-UNIT`
@@ -351,17 +351,17 @@ Deleted data can not be retrieved. Do use this command cautiously!
 
 `g/GENDER`
 * `M` or `F`
-* Not case-sensitive
+* Not case-sensitive *i.e. `m` and `f` is also valid*
 
 `h/HOUSE`
 * Represents the RC4 house that the resident is allocated to
 * Must be either `A`, `D`, `L`, `N`, `U`
 * `A` stands for **Aquila**, `D` stands for **Draco**, `L` for **Leo**, `N` for **Noctua**`U` for **Ursa**
-* Not case-sensitive
+* Not case-sensitive *i.e. `a`, `d`, `l`, `n` and `u` are also valid*
 
 `m/MATRIC_NUMBER`
 * Must be an uppercase `A`, followed by a **7**-digit non-negative integer and an uppercase alphabet. *i.e. `A0123456A`*
-* Not case-sensitive
+* Not case-sensitive *i.e. `a0123456b`, `A0123456b` and `a0123456B` are also valid*
 
 `t/TAG`
 * Represents any other key that could be used to identify a resident

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -206,6 +206,14 @@ if it is open. </div>
 In order to maintain the database, we have provided several basic commands such as `add`, `edit`, `delete` and `clear`
 to help you modify resident data within **RC4HDB**.
 
+Note:
+* **RC4HDB** does not allow duplicate residents to exist within the database, as a measure to prevent unintentional adding of duplicate residents.
+* Two residents are considered duplicate if they satisfy any of the following conditions:
+  * have the same **matriculation number**
+  * have the same **phone number**
+  * have the same **email**
+  * have the same **room**
+
 ---
 
 <div markdown="span" class="alert alert-info">:information_source: **Note:**
@@ -221,7 +229,7 @@ The resident [fields](#glossary-of-terms) can be found [here](#format-for-reside
 
 ### Adding a resident : `add`
 
-Adds a resident into **RC4HDB**.
+Adds a resident into **RC4HDB**. Does **not** allow any [duplicate residents](#modifying-resident-data) to be added.
 
 Format: `add n/NAME p/PHONE_NUMBER e/EMAIL r/FLOOR-UNIT g/GENDER h/HOUSE m/MATRIC_NUMBER [t/TAG]…​`
 
@@ -243,7 +251,7 @@ Examples:
 
 ### Editing an existing resident : `edit`
 
-Edits the data of an existing resident in **RC4HDB**.
+Edits the data of an existing resident in **RC4HDB**. Does **not** allow any [duplicate residents](#modifying-resident-data) to be created due to the editing of a resident.
 
 Format: `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [r/FLOOR-UNIT] [g/GENDER] [h/HOUSE] [m/MATRIC_NUMBER] [t/TAG]…​`
 
@@ -376,16 +384,14 @@ Lists *all* the residents in the **RC4HDB** database. If the table view is showi
 calling `list` will restore and display the full list of residents.
 
 Format:
-
-- `list` to display *all* residents from the database with *all* columns shown in the table.
+* `list` to display *all* residents from the database with *all* columns shown in the table.
   Calling `list` on our sample data will produce the following result:
   
 
   ![list command](images/ug-photos/list_command.png)
 
 Note:
-
-- Any input entered after the `list` command will be ignored.
+* Any input entered after the `list` command will be ignored.
 
 [↑ Back to Top](#welcome-to-rc4hdb-user-guide)
 
@@ -427,13 +433,13 @@ Sequential examples:
 
 Note:
 
-- Valid inputs include `i n p e r g h m t` (case-insensitive), which correspond to the first letter of each field in the table.
-  - This *should not* be confused with the `n/` or `p/` prefixes used in `add` or `filter`.
-- Letters *must* be separated by a single whitespace.
-- The order of each letter does not matter.
-- Duplicate letters are ignored. 
-- There needs to be at least one column shown in the table at all times.
-- You can always use `reset` to restore the full table view!
+* Valid inputs include `i n p e r g h m t` (case-insensitive), which correspond to the first letter of each field in the table.
+  * This *should not* be confused with the `n/` or `p/` prefixes used in `add` or `filter`.
+* Letters *must* be separated by a single whitespace.
+* The order of each letter does not matter.
+* Duplicate letters are ignored. 
+* There needs to be at least one column shown in the table at all times.
+* You can always use `reset` to restore the full table view!
 
 
 [↑ Back to Top](#welcome-to-rc4hdb-user-guide)
@@ -470,13 +476,13 @@ Sequential examples:
 
 Note:
 
-- Valid inputs include `i n p e r g h m t` (case-insensitive), which correspond to the first letter of each field in the table.
-    - This *should not* be confused with the `n/` or `p/` prefixes used in `edit` or `filter`.
-- Letters *must* be separated by a single whitespace.
-- The order of each letter does not matter.
-- Duplicate letters are ignored.
-- There needs to be at least one column shown in the table at all times.
-- You can always use `reset` to restore the full table view!
+* Valid inputs include `i n p e r g h m t` (case-insensitive), which correspond to the first letter of each field in the table.
+    * This *should not* be confused with the `n/` or `p/` prefixes used in `edit` or `filter`.
+* Letters *must* be separated by a single whitespace.
+* The order of each letter does not matter.
+* Duplicate letters are ignored.
+* There needs to be at least one column shown in the table at all times.
+* You can always use `reset` to restore the full table view!
 
 
 [↑ Back to Top](#welcome-to-rc4hdb-user-guide)
@@ -494,9 +500,9 @@ Use this when you have called `showonly` or `hideonly` on the table!
 Format: `reset`
 
 Note:
-- Any input entered after the `reset` command will be ignored.
-- This command is different from the `list` command in that it does not affect the list of residents being displayed.
-  - However, both commands cause the full set of resident fields to be displayed in the table.
+* Any input entered after the `reset` command will be ignored.
+* This command is different from the `list` command in that it does not affect the list of residents being displayed.
+  * However, both commands cause the full set of resident fields to be displayed in the table.
 
 [↑ Back to Top](#welcome-to-rc4hdb-user-guide)
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -208,11 +208,11 @@ to help you modify resident data within **RC4HDB**.
 
 Note:
 * **RC4HDB** does not allow duplicate residents to exist within the database, as a measure to prevent unintentional adding of duplicate residents.
-* Two residents are considered duplicate if they satisfy any of the following conditions:
-  * have the same **matriculation number**
-  * have the same **phone number**
-  * have the same **email**
-  * have the same **room**
+* Two residents are considered duplicate if they have the same:
+  * matriculation number
+  * phone number
+  * email
+  * room
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -208,7 +208,7 @@ to help you modify resident data within **RC4HDB**.
 
 Note:
 * **RC4HDB** does not allow duplicate residents to exist within the database, as a measure to prevent unintentional adding of duplicate residents.
-* Two residents are considered duplicate if they have the same:
+* Two residents are considered duplicates of each other if any of the following are same:
   * matriculation number
   * phone number
   * email

--- a/src/main/java/seedu/rc4hdb/model/StringField.java
+++ b/src/main/java/seedu/rc4hdb/model/StringField.java
@@ -28,8 +28,9 @@ public abstract class StringField {
      * @return true if the condition above is satisfied.
      */
     public boolean equalsIgnoreCase(StringField other) {
-        return this.isSubOrSuperClass(other)
-                && this.value.equalsIgnoreCase(other.value);
+        return other == this
+                || (this.isSubOrSuperClass(other)
+                && this.value.equalsIgnoreCase(other.value));
     }
 
     /**
@@ -38,7 +39,7 @@ public abstract class StringField {
      * @return true if the condition above is satisfied.
      */
     private boolean isSubOrSuperClass(StringField other) {
-        return other.getClass().equals(this.getClass());
+        return other != null && other.getClass().equals(this.getClass());
     }
 
     @Override

--- a/src/main/java/seedu/rc4hdb/model/StringField.java
+++ b/src/main/java/seedu/rc4hdb/model/StringField.java
@@ -28,9 +28,11 @@ public abstract class StringField {
      * @return true if the condition above is satisfied.
      */
     public boolean equalsIgnoreCase(StringField other) {
-        return other == this
-                || (this.isSubOrSuperClass(other)
-                && this.value.equalsIgnoreCase(other.value));
+        if (this == other) {
+            return false;
+        }
+        return this.isSubOrSuperClass(other)
+                && this.value.equalsIgnoreCase(other.value);
     }
 
     /**
@@ -39,7 +41,10 @@ public abstract class StringField {
      * @return true if the condition above is satisfied.
      */
     private boolean isSubOrSuperClass(StringField other) {
-        return other != null && other.getClass().equals(this.getClass());
+        if (other == null) {
+            return false;
+        }
+        return other.getClass().equals(this.getClass());
     }
 
     @Override

--- a/src/main/java/seedu/rc4hdb/model/StringField.java
+++ b/src/main/java/seedu/rc4hdb/model/StringField.java
@@ -23,10 +23,21 @@ public abstract class StringField {
     }
 
     /**
-     * Returns true if {@code other} is a subclass of {@code this} or if {@code this} is a subclass of {@code other}.
+     * Returns true if {@code other} and {@code this} comply to the sub or super class relation and their {@code value}
+     * must be the same, ignoring case (upper or lower).
      * @return true if the condition above is satisfied.
      */
-    private boolean isSubclass(StringField other) {
+    public boolean equalsIgnoreCase(StringField other) {
+        return this.isSubOrSuperClass(other)
+                && this.value.equalsIgnoreCase(other.value);
+    }
+
+    /**
+     * Returns true if {@code other} is a subclass of {@code this} or if {@code this} is a subclass of {@code other}
+     * during runtime.
+     * @return true if the condition above is satisfied.
+     */
+    private boolean isSubOrSuperClass(StringField other) {
         return other.getClass().equals(this.getClass());
     }
 
@@ -50,7 +61,7 @@ public abstract class StringField {
         }
 
         StringField otherField = (StringField) other;
-        return isSubclass(otherField)
+        return isSubOrSuperClass(otherField)
                 && value.equals(((StringField) other).value);
     }
 

--- a/src/main/java/seedu/rc4hdb/model/resident/Resident.java
+++ b/src/main/java/seedu/rc4hdb/model/resident/Resident.java
@@ -100,7 +100,10 @@ public class Resident implements BookingField {
         }
 
         return otherResident != null
-                && otherResident.getName().equals(getName());
+                && (otherResident.matricNumber.equals(this.matricNumber)
+                || otherResident.phone.equals(this.phone)
+                || otherResident.email.equalsIgnoreCase(this.email)
+                || otherResident.room.equals(this.room));
     }
 
     /**

--- a/src/main/java/seedu/rc4hdb/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/rc4hdb/model/util/SampleDataUtil.java
@@ -55,7 +55,7 @@ public class SampleDataUtil {
                     new Gender("M"), new House("N"), new MatricNumber("A0088134E"), getTagSet("PublicityHead")
             ),
             new Resident(
-                    new Name("Melvin Chua"), new Phone("91615761"), new Email("melvchua@gmail.com"), new Room("03-09"),
+                    new Name("Melvin Chua"), new Phone("91615761"), new Email("melvchua@gmail.com"), new Room("03-11"),
                     new Gender("M"), new House("A"), new MatricNumber("A0062330F"), getTagSet("TechLead")
             ),
 
@@ -85,7 +85,7 @@ public class SampleDataUtil {
             ),
 
             new Resident(
-                    new Name("Nur Farah"), new Phone("91834331"), new Email("farahnur@gmail.com"), new Room("04-05"),
+                    new Name("Nur Farah"), new Phone("91834331"), new Email("farahnur@gmail.com"), new Room("04-06"),
                     new Gender("F"), new House("N"), new MatricNumber("A0203046L"), getTagSet("HouseHead")
             ),
 

--- a/src/test/java/seedu/rc4hdb/model/resident/ResidentTest.java
+++ b/src/test/java/seedu/rc4hdb/model/resident/ResidentTest.java
@@ -34,23 +34,17 @@ public class ResidentTest {
         // null -> returns false
         assertFalse(ALICE.isSameResident(null));
 
-        // same name, all other attributes different -> returns true
-        Resident editedAlice = new ResidentBuilder(ALICE).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
-                .withRoom(VALID_ROOM_BOB).withTags(VALID_TAG_HUSBAND).build();
-        assertTrue(ALICE.isSameResident(editedAlice));
+        // EP: same everything but not same of one of the following:
+        // matricNumber, phone, email or room -> return true
+        assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withMatricNumber(VALID_MATRIC_NUMBER_BOB).build()));
+        assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withPhone(VALID_PHONE_BOB).build()));
+        assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build()));
+        assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withRoom(VALID_ROOM_BOB).build()));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new ResidentBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSameResident(editedAlice));
-
-        // name differs in case, all other attributes same -> returns false
-        Resident editedBob = new ResidentBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSameResident(editedBob));
-
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new ResidentBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSameResident(editedBob));
+        // EP: all 4 of the following not same:
+        // matricNumber, phone, email and room -> return false
+        assertFalse(ALICE.isSameResident(new ResidentBuilder(ALICE).withMatricNumber(VALID_MATRIC_NUMBER_BOB)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withRoom(VALID_ROOM_BOB).build()));
     }
 
     @Test
@@ -68,7 +62,7 @@ public class ResidentTest {
         // different type -> returns false
         assertFalse(ALICE.equals(5));
 
-        // different person -> returns false
+        // different resident -> returns false
         assertFalse(ALICE.equals(BOB));
 
         // different name -> returns false

--- a/src/test/java/seedu/rc4hdb/model/resident/ResidentTest.java
+++ b/src/test/java/seedu/rc4hdb/model/resident/ResidentTest.java
@@ -40,6 +40,8 @@ public class ResidentTest {
         assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withPhone(VALID_PHONE_BOB).build()));
         assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withEmail(VALID_EMAIL_BOB).build()));
         assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withRoom(VALID_ROOM_BOB).build()));
+        // email uniqueness is case-insensitive
+        assertTrue(ALICE.isSameResident(new ResidentBuilder(ALICE).withEmail(VALID_EMAIL_BOB.toUpperCase()).build()));
 
         // EP: all 4 of the following not same:
         // matricNumber, phone, email and room -> return false

--- a/src/test/java/seedu/rc4hdb/model/resident/fields/EmailTest.java
+++ b/src/test/java/seedu/rc4hdb/model/resident/fields/EmailTest.java
@@ -2,6 +2,8 @@ package seedu.rc4hdb.model.resident.fields;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.rc4hdb.logic.commands.ModelCommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.rc4hdb.logic.commands.ModelCommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.rc4hdb.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +27,19 @@ public class EmailTest {
     @Test
     public void constructor_validEmail_constructEmail() {
         assertTrue(new Email("valid@email.com") instanceof Email);
+    }
+
+    @Test
+    public void equalsIgnoreCase() {
+        // null email
+        assertFalse(new Email(VALID_EMAIL_AMY).equalsIgnoreCase(null));
+
+        // EP: same characters case-insensitive -> return true
+        assertTrue(new Email(VALID_EMAIL_AMY).equalsIgnoreCase(new Email(VALID_EMAIL_AMY)));
+        assertTrue(new Email(VALID_EMAIL_AMY).equalsIgnoreCase(new Email(VALID_EMAIL_AMY.toUpperCase())));
+
+        // EP: different characters
+        assertFalse(new Email(VALID_EMAIL_AMY).equalsIgnoreCase(new Email(VALID_EMAIL_BOB)));
     }
 
     @Test


### PR DESCRIPTION
Refer to #188 for more details.

#### Changed:
* `Resident::isSameResident` method now checks if phone, room and matric number fields are equal.
* `Resident::isSameResident` method now checks if email fields are equal (case-insensitive).
* Updated UG to specify that duplicate residents are not allowed and defined the conditions for residents to be considered duplicates.
* Updated `ResidentTest` `isSameResident` test to fit the new definition of uniqueness.
* Updated `SampleDataUtil` to make sure residents are all unique.
* Updated `EmailTest` to test the newly added `StringField::equalsIgnoreCase` method.